### PR TITLE
ci(release): change ubuntu-18 to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     # specify the environment to select the right env variables
     environment: build
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     if: "!contains(github.event.head_commit.message, 'chore(release)')"
 


### PR DESCRIPTION
GitHub didn't warn anyone and they're now limiting the amount of runners using ubuntu 18.
https://github.com/actions/runner-images/issues/6002

Thanks, @nickcharlton, for the tip.